### PR TITLE
Create Toggleable Platforms

### DIFF
--- a/src/levels/level1.ts
+++ b/src/levels/level1.ts
@@ -9,6 +9,8 @@ import { SquarePlayer } from "../characters/squarePlayer";
 import { ResourceLoader } from "merlin-game-engine/dist/resources/resource";
 import { ImageTexture, TiledTexture } from "merlin-game-engine/dist/resources/textures";
 import RightNormalV3 from "../../assets/player/rightNormalV3.svg";
+import { TogglePlatform } from "../togles/togglePlatform";
+import { Lever } from "../togles/lever";
 
 export class Level1 implements Level {
     constructor() {}
@@ -33,9 +35,19 @@ export class Level1 implements Level {
             new StaticBody(new Vector2(0, Utils.GAME_HEIGHT - 128), new Vector2(1280, 128), 0b1, 0b1, 0.8, "ground")
                 .addChild(new AABB(Vector2.zero(), new Vector2(1280, 128), true, "groundCollider"))
                 .addChild(new TextureRect(Vector2.zero(), new Vector2(1280, 128), ground, "groundTexture")),
+           
             new Region(new Vector2(900, Utils.GAME_HEIGHT - 256), new Vector2(128, 128), 0b1, 0b1, "endBox")
                 .addChild(new AABB(Vector2.zero(), new Vector2(128, 128), true, "endBoxCollider"))
-                .addChild(new ColorRect(Vector2.zero(), new Vector2(128, 128), "orange", "endBoxTexture"))
+                .addChild(new ColorRect(Vector2.zero(), new Vector2(128, 128), "orange", "endBoxTexture")),
+
+            new TogglePlatform(new Vector2(512, Utils.GAME_HEIGHT - 256), new Vector2(128, 128), 1, "toggle1")
+                .addChild(new AABB(Vector2.zero(), new Vector2(128, 128), true, "toggle1Collider"))
+                .addChild(new ColorRect(Vector2.zero(), new Vector2(128, 128), "#ffff00", "toggle1Texture")),
+
+            new Lever(new Vector2(128, Utils.GAME_HEIGHT - 256), new Vector2(128, 128), 1, "lever1")
+                .addChild(new AABB(Vector2.zero(), new Vector2(128, 128), true, "lever1Collider"))
+                .addChild(new ColorRect(Vector2.zero(), new Vector2(128, 128), "#ff00ff", "lever1Texture"))
+
         ];
 
         return gameObjects;

--- a/src/levels/level1.ts
+++ b/src/levels/level1.ts
@@ -11,6 +11,7 @@ import { ImageTexture, TiledTexture } from "merlin-game-engine/dist/resources/te
 import RightNormalV3 from "../../assets/player/rightNormalV3.svg";
 import { TogglePlatform } from "../togles/togglePlatform";
 import { Lever } from "../togles/lever";
+import { Button } from "../togles/button";
 
 export class Level1 implements Level {
     constructor() {}
@@ -44,10 +45,13 @@ export class Level1 implements Level {
                 .addChild(new AABB(Vector2.zero(), new Vector2(128, 128), true, "toggle1Collider"))
                 .addChild(new ColorRect(Vector2.zero(), new Vector2(128, 128), "#ffff00", "toggle1Texture")),
 
-            new Lever(new Vector2(128, Utils.GAME_HEIGHT - 256), new Vector2(128, 128), 1, "lever1")
+            new Lever(new Vector2(672, 600 - 128), new Vector2(128, 128), 1, "lever1")
                 .addChild(new AABB(Vector2.zero(), new Vector2(128, 128), true, "lever1Collider"))
-                .addChild(new ColorRect(Vector2.zero(), new Vector2(128, 128), "#ff00ff", "lever1Texture"))
+                .addChild(new ColorRect(Vector2.zero(), new Vector2(128, 128), "#ff00ff", "lever1Texture")),
 
+            new Button(new Vector2(0, Utils.GAME_HEIGHT - 256), new Vector2(128, 128), 1, "lever1")
+                .addChild(new AABB(Vector2.zero(), new Vector2(128, 128), true, "lever1Collider"))
+                .addChild(new ColorRect(Vector2.zero(), new Vector2(128, 128), "#00ffff", "lever1Texture"))
         ];
 
         return gameObjects;

--- a/src/states/testGame.ts
+++ b/src/states/testGame.ts
@@ -19,7 +19,7 @@ export class TestGame extends GameState {
   private levelData: Level[];
   private loadedLevel?: GameObjectTree;
   //controls level VVVVVV
-  private currentLevel: number = 2;
+  private currentLevel: number = 1;
   private physics: PhysicsEngine;
   private loading: boolean;
   

--- a/src/togles/button.ts
+++ b/src/togles/button.ts
@@ -1,0 +1,18 @@
+import { Region } from "merlin-game-engine/dist/gameObjects/physicsObjects";
+import { Vector2 } from "merlin-game-engine/dist/math/vector2";
+import { Utils } from "merlin-game-engine/dist/utils";
+
+export class Button extends Region {
+    private toggleIndex: number;
+
+    constructor(position: Vector2, size: Vector2, toggleIdex: number, name: string) {
+        super(position, size, 0b1, 0b1, name);
+        this.toggleIndex = toggleIdex;
+    }
+
+    override onRegionEnter(region: Region): void {
+        if (region.getName().toLowerCase().includes("player")) {
+            Utils.broadcast("togglePlatform", this.toggleIndex);
+        }
+    }
+}

--- a/src/togles/lever.ts
+++ b/src/togles/lever.ts
@@ -1,0 +1,24 @@
+import { Region } from "merlin-game-engine/dist/gameObjects/physicsObjects";
+import { Vector2 } from "merlin-game-engine/dist/math/vector2";
+import { Utils } from "merlin-game-engine/dist/utils";
+
+export class Lever extends Region {
+    private toggleIndex: number;
+
+    constructor(position: Vector2, size: Vector2, toggleIndex: number, name: string) {
+        super(position, size, 0b1, 0b1, name);
+        this.toggleIndex = toggleIndex;
+    }
+
+    override onRegionEnter(region: Region): void {
+        if (region.getName().toLowerCase().includes("player")) {
+            Utils.broadcast("togglePlatform", this.toggleIndex);
+        }
+    }
+
+    override onRegionExit(region: Region): void {
+        if (region.getName().toLowerCase().includes("player")) {
+            Utils.broadcast("togglePlatform", this.toggleIndex);
+        }
+    }
+}

--- a/src/togles/togglePlatform.ts
+++ b/src/togles/togglePlatform.ts
@@ -1,0 +1,19 @@
+import { StaticBody, Region, AABB } from "merlin-game-engine/dist/gameObjects/physicsObjects";
+import { Vector2 } from "merlin-game-engine/dist/math/vector2";
+import { Utils } from "merlin-game-engine/dist/utils";
+
+export class TogglePlatform extends StaticBody {
+    private toggleIndex: number;
+
+    constructor(position: Vector2, size: Vector2, toggleIndex: number, name: string) {
+        super(position, size, 0b1, 0b1, 0.8, name);
+        this.toggleIndex = toggleIndex;
+        Utils.listen("togglePlatform", (index: number) => {
+            if (index !== toggleIndex) return;
+
+            const collider = this.getChildrenType<AABB>(AABB)[0];
+            collider.setVisible(!collider.isVisible());
+            this.visible = !this.visible;
+        });
+    }
+}


### PR DESCRIPTION
This creates 3 new GameObjects: Levers, Buttons, and TogglePlatforms.

TogglePlatforms listen for the "togglePlatform" message. The "togglePlatform" message should include a number that indicates what platforms should be toggled. TogglePlatforms have a `toggleIndex` property that describes what lever or button it should react to.

Levers are Regions that whenever the player or squarePlayer goes inside, it broadcasts the "togglePlatform" message. Levers also broadcast the message when either player leaves intersection of the Lever.

Buttons are identical to Levers, except that they do not broadcast the message when either player leaves it.

Levers and Buttons have `toggleIndex` properties that determine what platform(s) it will toggle when it is triggered. Levers or Buttons can toggle multiple platforms, as long as the platforms are on the same index.