### PR TITLE
Add the ability to create disabled togglePlatform

### DIFF
--- a/src/levels/level1.ts
+++ b/src/levels/level1.ts
@@ -45,8 +45,8 @@ export class Level1 implements Level {
                 .addChild(new AABB(Vector2.zero(), new Vector2(128, 128), true, "endBoxCollider"))
                 .addChild(new ColorRect(Vector2.zero(), new Vector2(128, 128), "orange", "endBoxTexture")),
 
-            new TogglePlatform(new Vector2(512, Utils.GAME_HEIGHT - 256), new Vector2(128, 128), 1, "toggle1")
-                .addChild(new AABB(Vector2.zero(), new Vector2(128, 128), true, "toggle1Collider"))
+            new TogglePlatform(new Vector2(512, Utils.GAME_HEIGHT - 256), new Vector2(128, 128), 1, false, "toggle1")
+                .addChild(new AABB(Vector2.zero(), new Vector2(128, 128), false, "toggle1Collider"))
                 .addChild(new ColorRect(Vector2.zero(), new Vector2(128, 128), "#ffff00", "toggle1Texture")),
 
             new Lever(new Vector2(672, 600 - 128), new Vector2(128, 128), 1, "lever1")

--- a/src/togles/togglePlatform.ts
+++ b/src/togles/togglePlatform.ts
@@ -5,15 +5,20 @@ import { Utils } from "merlin-game-engine/dist/utils";
 export class TogglePlatform extends StaticBody {
     private toggleIndex: number;
 
-    constructor(position: Vector2, size: Vector2, toggleIndex: number, name: string) {
+    constructor(position: Vector2, size: Vector2, toggleIndex: number, isToggled: boolean, name: string) {
         super(position, size, 0b1, 0b1, 0.8, name);
         this.toggleIndex = toggleIndex;
-        Utils.listen("togglePlatform", (index: number) => {
-            if (index !== toggleIndex) return;
+        this.visible = isToggled;
 
-            const collider = this.getChildrenType<AABB>(AABB)[0];
-            collider.setVisible(!collider.isVisible());
-            this.visible = !this.visible;
+        Utils.listen("togglePlatform", (index: number) => {
+            if (index !== this.toggleIndex) return;
+
+            this.toggle(!this.visible);
         });
+    }
+
+    protected toggle(desiredState: boolean) {
+        this.getChildrenType<AABB>(AABB)[0].setVisible(desiredState);
+        this.visible = desiredState;
     }
 }


### PR DESCRIPTION
Add a parameter in the TogglePlatform constructor that defines whether it should start out as disabled. The colliding shape's enablement MUST match the enablement in the TogglePlatform constructor.