### PR TITLE
Create a Goal object

### DIFF
--- a/src/characters/player.ts
+++ b/src/characters/player.ts
@@ -58,9 +58,7 @@ export class Player extends KinematicBody {
 
 
     override onRegionEnter(region: Region): void {
-      if (region.getName() == "endBox") {
-        Utils.broadcast("nextLevel");
-      } else if (region.getName().toLowerCase().includes("spike")) {
+      if (region.getName().toLowerCase().includes("spike")) {
         this.willDie = true;
       }
     }

--- a/src/goal.ts
+++ b/src/goal.ts
@@ -1,0 +1,21 @@
+import { KinematicBody, Region } from "merlin-game-engine/dist/gameObjects/physicsObjects";
+import { Vector2 } from "merlin-game-engine/dist/math/vector2";
+import { Player } from "./characters/player";
+import { SquarePlayer } from "./characters/squarePlayer";
+import { Utils } from "merlin-game-engine/dist/utils";
+import { log } from "merlin-game-engine";
+
+export class Goal extends Region {
+    constructor(position: Vector2, size: Vector2) {
+        super(position, size, 0b1, 0b1, "goal");
+    }
+
+    override update(dt: number): void {
+        log("goalRegionsInside: ", this.regionsInside.map((region: Region) => region.getName()));
+        const platformerPlayerInside = this.regionsInside.filter((otherRegion: Region) => otherRegion instanceof Player).length;
+        const squarePlayerInside = this.regionsInside.filter((otherRegion: Region) => otherRegion instanceof SquarePlayer).length;
+        if (platformerPlayerInside > 0 && squarePlayerInside > 0) {
+            Utils.broadcast("nextLevel");
+        }
+    }
+}

--- a/src/levels/level0.ts
+++ b/src/levels/level0.ts
@@ -9,6 +9,7 @@ import { SquarePlayer } from "../characters/squarePlayer";
 import { ResourceLoader } from "merlin-game-engine/dist/resources/resource";
 import { ImageTexture, TiledTexture } from "merlin-game-engine/dist/resources/textures";
 import RightNormalV3 from "../../assets/player/rightNormalV3.svg";
+import { Goal } from "../goal";
 
 function wait(delay: number): Promise<void> {
     return new Promise<void>((resolve, reject) => {
@@ -35,12 +36,11 @@ export class Level0 implements Level {
             new StaticBody(new Vector2(0, Utils.GAME_HEIGHT - 128), new Vector2(1280, 128), 0b1, 0b1, 0.8, "ground")
                 .addChild(new AABB(Vector2.zero(), new Vector2(1280, 128), true, "groundCollider"))
                 .addChild(new TextureRect(Vector2.zero(), new Vector2(1280, 128), ground, "groundTexture")),
-            new Region(new Vector2(900, Utils.GAME_HEIGHT - 256), new Vector2(128, 128), 0b1, 0b1, "endBox")
-                .addChild(new AABB(Vector2.zero(), new Vector2(128, 128), true, "endBoxCollider"))
-                .addChild(new ColorRect(Vector2.zero(), new Vector2(128, 128), "orange", "endBoxTexture"))
-        ];
-        await wait(10000);
 
+            new Goal(new Vector2(900, Utils.GAME_HEIGHT - 256), new Vector2(128, 128))
+                .addChild(new AABB(Vector2.zero(), new Vector2(128, 128), true, "goalCollider"))
+                .addChild(new ColorRect(Vector2.zero(), new Vector2(128, 128), "orange", "goalTexture"))
+        ];
 
         return gameObjects;
     }

--- a/src/states/testGame.ts
+++ b/src/states/testGame.ts
@@ -19,7 +19,7 @@ export class TestGame extends GameState {
   private levelData: Level[];
   private loadedLevel?: GameObjectTree;
   //controls level VVVVVV
-  private currentLevel: number = 1;
+  private currentLevel: number = 0;
   private physics: PhysicsEngine;
   private loading: boolean;
   


### PR DESCRIPTION
Create a Goal object that broadcasts the "nextLevel" message. The Goal takes in a position and size in its constructor. When a player and a squarePlayer are inside it at the same time, the goal will broadcast the "nextLevel" message.

Remove the ability to broadcast the "nextLevel" message from the player for compatability with the new goal system.