### PR TITLE
Keep the square player's velocity on collision

### DIFF
--- a/src/characters/squarePlayer.ts
+++ b/src/characters/squarePlayer.ts
@@ -1,13 +1,15 @@
 import { keyboardHandler, log } from "merlin-game-engine";
 import { KinematicBody, Region } from "merlin-game-engine/dist/gameObjects/physicsObjects";
 import { Vector2 } from "merlin-game-engine/dist/math/vector2";
-import { PhysicsEngine } from "merlin-game-engine/dist/physicsEngine/physics";
+import { CollisionData, PhysicsEngine } from "merlin-game-engine/dist/physicsEngine/physics";
 import { Utils } from "merlin-game-engine/dist/utils";
+import { Player } from "./player";
 
 export class SquarePlayer extends KinematicBody {
     private spawnpoint: Vector2;
     private speed: number = 0.5;
     private willDie: boolean = false;
+    private direction: Vector2 = Vector2.zero();
 
     constructor(spawnpoint: Vector2, name: string) {
         super(spawnpoint, new Vector2(128, 128), 0b1, 0b1, Vector2.zero(), false, 0.8, name);
@@ -17,15 +19,19 @@ export class SquarePlayer extends KinematicBody {
     override update(dt: number): void {
         log("Update squarePlayer");
         log("Square Velocity: ", this.velocity);
-        if (keyboardHandler.keyJustPressed("ArrowRight") && this.velocity.equals(Vector2.zero())) {
-            this.velocity.x = this.speed;
-        } else if (keyboardHandler.keyJustPressed("ArrowLeft") && this.velocity.equals(Vector2.zero())) {
-            this.velocity.x = -this.speed;
-        } else if (keyboardHandler.keyJustPressed("ArrowUp") && this.velocity.equals(Vector2.zero())) {
-            this.velocity.y = -this.speed;
-        } else if (keyboardHandler.keyJustPressed("ArrowDown") && this.velocity.equals(Vector2.zero())) {
-            this.velocity.y = this.speed;
+        log("Square Direction: ", this.direction);
+        if (keyboardHandler.keyJustPressed("ArrowRight") && this.direction.equals(Vector2.zero())) {
+            this.direction.x = 1;
+        } else if (keyboardHandler.keyJustPressed("ArrowLeft") && this.direction.equals(Vector2.zero())) {
+            this.direction.x = -1;
+        } else if (keyboardHandler.keyJustPressed("ArrowUp") && this.direction.equals(Vector2.zero())) {
+            this.direction.y = -1;
+        } else if (keyboardHandler.keyJustPressed("ArrowDown") && this.direction.equals(Vector2.zero())) {
+            this.direction.y = 1;
         }
+
+        const desiredVelocity = this.direction.multiply(this.speed);
+        if (!this.velocity.equals(desiredVelocity)) this.velocity = desiredVelocity;
 
         this.willDie = this.willDie || this.shouldDie();
 
@@ -41,6 +47,18 @@ export class SquarePlayer extends KinematicBody {
     override onRegionEnter(region: Region): void {
         if (region.getName().toLowerCase().includes("spike")) {
             this.willDie = true;
+        }
+    }
+
+    override onCollision(collision: CollisionData): void {
+        const otherCollider = collision.colliderA === this ? collision.colliderB : collision.colliderA;
+        log("Squareplayer OnCollision");
+        log("otherCollider: ", otherCollider?.getName());
+
+        log("collisionNormal: ", collision.normal);
+        log("direction: ", this.direction);
+        if (otherCollider !== undefined && !(otherCollider instanceof Player) && !this.direction.equals(Vector2.zero()) && collision.normal.abs().equals(this.direction.abs())) {
+            this.direction = Vector2.zero();
         }
     }
 


### PR DESCRIPTION
When the square player collides with the player, its velocity will not be affected because each frame, it is checking its velocity with its expected velocity. If the velocities don't match, then the velocity of the square player will be set to the desired velocity. The desired veloctity will be reset when there is a collision with a non-player object along the same axis as the direction of the squareplayer.