### PR TITLE
Stop the game when finished

### DIFF
--- a/src/states/testGame.ts
+++ b/src/states/testGame.ts
@@ -40,7 +40,8 @@ export class TestGame extends GameState {
 
     Utils.listen("nextLevel", () => {
       if (this.currentLevel == this.levelData.length - 1 && !this.loading) {
-        alert("You finished the game!");
+        alert("You finished the game! Reload to play again.");
+        this.paused = true;
       } else if (!this.loading) {
         this.changeLevel(this.currentLevel + 1);
       }      


### PR DESCRIPTION
When the game is finished (i.e. `nextLevel` is broadcasted, but currentLevel is at the end of the levelData array), pause the TestGame state.

Update the finish game dialog to tell the player to reload the page to play again